### PR TITLE
Resolved compatibility with Nette 2.4, use Nette/SmartObject instead …

### DIFF
--- a/src/GpsPoint.php
+++ b/src/GpsPoint.php
@@ -9,9 +9,13 @@ use Nette;
  * Single point
  *
  * @author Vojtěch Dobeš
+ * @property-read float $lat
+ * @property-read float $lng
+ * @property-read string $address  
  */
-class GpsPoint extends Nette\Object
+class GpsPoint
 {
+	use Nette\SmartObject;
 
 	/** @var float */
 	private $lat;


### PR DESCRIPTION
Nette 2.4 throws warning E_USER_DEPRECATED by using deprecated Nette/Object.